### PR TITLE
adding VPC id as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,11 @@ output db_security_group_id {
   value = aws_security_group.db.id
 }
 
+output network_vpc_id {
+  description = "The id of the newly created VPC"
+  value       = module.network.vpc_id
+}
+
 output network_public_subnet_ids {
   description = "public vpc subnets"
   value       = module.network.public_subnet_ids


### PR DESCRIPTION
adding the VPC ID as an output param from the network blueprint so I can use it for the ALB creation

it's more convenient for me to get it from here than from SSM since I'm not familiar with that